### PR TITLE
Fix invalid xpath expression

### DIFF
--- a/R/xml_convert.r
+++ b/R/xml_convert.r
@@ -291,7 +291,7 @@ xml_to_df <- function(file = NULL, text = NULL, first.records = NULL, xml.encodi
 
   xp <- ""
   if(!is.null(records.tags)) xp <- paste0("//", records.tags, collapse = " | ")
-  if(!is.null(records.xpath)) xp <- paste(xp, paste0(records.xpath, collapse = " | "), sep = " | ")
+  if(!is.null(records.xpath)) xp <- paste0(records.xpath, collapse = " | ")
   recs <- xml2::xml_find_all(xml, xp)
 
   df <- data.frame()

--- a/man/xml_to_df.Rd
+++ b/man/xml_to_df.Rd
@@ -54,11 +54,11 @@ name). All elements with this tag name will be considered data records.
 Instead of specifying the tag name, an XPatch expression can be used to
 identify the data records (see \code{records.xpath})}
 
-\item{records.xpath}{XPath expression that specifies the XML element to be
-selected as data records; can be used instead of specifying the data record
-XML tags directly with the \code{data.records} argument. If both,
-\code{records.tags} and \code{records.path} are provided, only the XPath
-expressions determines the tags to be selected.}
+\item{records.xpath}{XPath expression (or vector of expressions) that specifies
+ the XML element to be selected as data records; can be used instead of
+ specifying the data record XML tags directly with the \code{data.records}
+ argument. If both, \code{records.tags} and \code{records.path} are provided,
+ only the XPath expressions determines the tags to be selected.}
 
 \item{fields}{A character value, either \code{"tags"} or \code{"attributes"}.
 Specifies whether the fields of each data record are represented as XML tags


### PR DESCRIPTION
Joining xpath expressions results in an invalid one beginning with pipe.